### PR TITLE
fix(reward): 修复时长奖品消耗数量输入框 backspace 无法删除的 bug

### DIFF
--- a/core/core-ui/src/main/kotlin/com/mushroom/core/ui/NumberTextField.kt
+++ b/core/core-ui/src/main/kotlin/com/mushroom/core/ui/NumberTextField.kt
@@ -1,0 +1,54 @@
+package com.mushroom.core.ui
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardType
+
+/**
+ * 数字输入框组件，封装正确的"字符串状态 + 数字解析"模式。
+ *
+ * 解决了以下问题：
+ * - 用户按 backspace 删除最后一位数字时，不应自动重置为 1
+ * - 空字符串应允许存在，而不是被强制转换为默认值
+ *
+ * 使用方式：
+ * - 状态类型为 String，直接对应 OutlinedTextField 的 value
+ * - onValueChange 回调接收的也是 String，空字符串表示用户清空了输入
+ * - 调用方负责解析和验证（如 toIntOrNull()）
+ *
+ * @param value 当前文本值（字符串）
+ * @param onValueChange 文本变化回调，接收新文本字符串
+ * @param label 标签文本
+ * @param modifier 修饰符
+ * @param isError 是否显示错误状态
+ * @param supportingText 辅助文本（Composable lambda）
+ * @param textStyle 文本样式
+ * @param enabled 是否可用
+ */
+@Composable
+fun NumberTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    isError: Boolean = false,
+    supportingText: (@Composable () -> Unit)? = null,
+    textStyle: TextStyle? = null,
+    enabled: Boolean = true
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = label,
+        modifier = modifier,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        singleLine = true,
+        isError = isError,
+        supportingText = supportingText,
+        textStyle = textStyle ?: TextStyle(),
+        enabled = enabled
+    )
+}

--- a/feature/feature-reward/src/main/kotlin/com/mushroom/feature/reward/ui/RewardDetailScreen.kt
+++ b/feature/feature-reward/src/main/kotlin/com/mushroom/feature/reward/ui/RewardDetailScreen.kt
@@ -20,8 +20,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -62,6 +60,7 @@ import coil.compose.AsyncImage
 import java.io.File
 import com.mushroom.core.domain.entity.MushroomLevel
 import com.mushroom.core.domain.entity.RewardType
+import com.mushroom.core.ui.NumberTextField
 import com.mushroom.core.ui.themedDisplayName
 import com.mushroom.core.ui.themedEmoji
 import com.mushroom.core.ui.R as CoreUiR
@@ -366,7 +365,8 @@ private fun TimePointsExchangeCard(
     onExchange: (MushroomLevel, Int) -> Unit
 ) {
     var selectedLevel by remember { mutableStateOf(MushroomLevel.SMALL) }
-    var amount by remember { mutableStateOf(1) }
+    var amountText by remember { mutableStateOf("1") }
+    val amount = amountText.toIntOrNull() ?: 0
 
     val contributedPoints = amount * selectedLevel.exchangePoints
     val costPoints = config.costPoints ?: return
@@ -435,17 +435,11 @@ private fun TimePointsExchangeCard(
             )
 
             // 数量选择
-            OutlinedTextField(
-                value = amount.toString(),
-                onValueChange = { newVal ->
-                    val parsed = newVal.toIntOrNull()
-                    if (parsed != null && parsed >= 1) amount = parsed
-                    else if (newVal.isEmpty()) amount = 1
-                },
+            NumberTextField(
+                value = amountText,
+                onValueChange = { newVal -> amountText = newVal },
                 label = { Text("消耗数量") },
-                modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                singleLine = true
+                modifier = Modifier.fillMaxWidth()
             )
 
             // 预览


### PR DESCRIPTION
## Summary
- 修复 `TimePointsExchangeCard` 中"消耗数量"输入框的 backspace bug（issue #18）
- 根因：使用 `Int` 状态 + `toString()` 转换时，`isEmpty() → amount = 1` 导致最后一位无法删除
- 修复：改用 `String` 状态直接存储用户输入，消除 Int ↔ String 转换的边界问题
- 新增 `NumberTextField` 可复用组件，封装正确的数字输入模式

## Test Plan
- [ ] 进入"奖品菜单" → 选择一个已创建的"时长奖品" → 进入详情页
- [ ] 在"消耗数量"输入框输入"90"
- [ ] 按 backspace → 显示"9" → 再按 backspace → 应能清空（或显示空），不再卡在"1"

refs #18

🤖 Generated with [Claude Code](https://claude.ai/code)